### PR TITLE
fix: fix string metric bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# IDE
+.vscode
+*code-workspace


### PR DESCRIPTION
This pull request fixes a bug that caused the `liquidity-exporter` to crash when [liquidctl](https://github.com/liquidctl/liquidctl) contained metrics that are of type string. The new code filters out these metrics and only publishes float64 metrics. Since I do not use these myself, I did not implement any logic for saving string-based metrics into the Prometheus database. 